### PR TITLE
build dependent modules w/ hardening flags by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-epics-base (3.15.3-2) UNRELEASED; urgency=medium
+epics-base (3.15.3-2) unstable; urgency=medium
 
   * Add /etc/epics/configure/conf.d/05hardening.make
     so that downstream builds for Linux targets use hardening
     flags by default.
     Can be overridden by defining 'SKIP_HARDENING=YES'
 
- -- Michael Davidsaver <mdavidsaver@gmail.com>  Tue, 19 Jan 2016 21:41:44 -0500
+ -- Michael Davidsaver <mdavidsaver@gmail.com>  Wed, 20 Jan 2016 11:10:55 -0500
 
 epics-base (3.15.3-1) unstable; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+epics-base (3.15.3-2) UNRELEASED; urgency=medium
+
+  * Add /etc/epics/configure/conf.d/05hardening.make
+    so that downstream builds for Linux targets use hardening
+    flags by default.
+    Can be overridden by defining 'SKIP_HARDENING=YES'
+
+ -- Michael Davidsaver <mdavidsaver@gmail.com>  Tue, 19 Jan 2016 21:41:44 -0500
+
 epics-base (3.15.3-1) unstable; urgency=medium
 
   * Imported Upstream version 3.15.3

--- a/debian/gen-harden.sh
+++ b/debian/gen-harden.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+export DEB_CPPFLAGS_STRIP="-g -O2"
+export DEB_CFLAGS_STRIP="-g -O2"
+export DEB_CXXFLAGS_STRIP="-g -O2"
+
+
+CPPFLAGS=`dpkg-buildflags --get CPPFLAGS`
+CFLAGS=`dpkg-buildflags --get CFLAGS`
+CXXFLAGS=`dpkg-buildflags --get CXXFLAGS`
+LDFLAGS=`dpkg-buildflags --get LDFLAGS`
+
+cat << EOF
+# set SKIP_HARDENING=YES to disable
+ifneq (\$(SKIP_HARDENING),YES)
+ifeq (\$(OS_CLASS),Linux)
+
+TARGET_CPPFLAGS = $CPPFLAGS
+TARGET_CFLAGS = $CFLAGS
+TARGET_CXXFLAGS = $CXXFLAGS
+TARGET_LDFLAGS = $LDFLAGS
+
+endif
+endif
+EOF

--- a/debian/rules
+++ b/debian/rules
@@ -25,12 +25,6 @@ export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 export DEB_CFLAGS_STRIP = -g -O2
 export DEB_CXXFLAGS_STRIP = -g -O2
 
-# Add Debian flags to the EPICS build
-DEB_USR_CXXFLAGS:=$(shell dpkg-buildflags --get CXXFLAGS)
-DEB_USR_CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
-DEB_USR_CPPFLAGS:=$(shell dpkg-buildflags --get CPPFLAGS)
-DEB_USR_LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
-
 # chop out the source version from Changelog (ie 3.14.12)
 # Taken from CDBS
 DEB_VERSION = $(shell dpkg-parsechangelog | egrep '^Version:' | cut -f 2 -d ' ')
@@ -54,17 +48,18 @@ export SHRLIB_VERSION=$(SOV)
 %:
 	dh $@ --with epics -Sepicsmake --parallel
 
+override_dh_auto_clean:
+	dh_auto_clean
+	rm -rf configure/conf.d
+
 override_dh_auto_build:
-	dh_auto_build -- FINAL_LOCATION=/usr/lib/epics EPICS_SITE_VERSION=$(DEBV) \
-	USR_CFLAGS_Linux="$(DEB_USR_CFLAGS)" \
-	USR_CXXFLAGS_Linux="$(DEB_USR_CXXFLAGS)" \
-	USR_CPPFLAGS_Linux="$(DEB_USR_CPPFLAGS)" \
-	USR_LDFLAGS_Linux="$(DEB_USR_LDFLAGS)"
+	install -d configure/conf.d
+	./debian/gen-harden.sh > configure/conf.d/05hardening.make
+	dh_auto_build -- FINAL_LOCATION=/usr/lib/epics EPICS_SITE_VERSION=$(DEBV)
 	sed -i -e "s|\$$ENV{EPICS_HOST_ARCH}|$(EPICS_HOST_ARCH)|g" bin/*/makeBaseApp.pl
 
 override_dh_auto_install:
-	dh_auto_install -- FINAL_LOCATION=/usr/lib/epics EPICS_SITE_VERSION=$(DEBV) \
-	USR_LDFLAGS_Linux="$(DEB_USR_LDFLAGS)"
+	dh_auto_install -- FINAL_LOCATION=/usr/lib/epics EPICS_SITE_VERSION=$(DEBV)
 
 override_dh_auto_test: # skip for development
 
@@ -96,6 +91,7 @@ override_dh_install:
 	done
 
 	install -d debian/tmp/etc/epics/configure/conf.d
+	cp configure/conf.d/05hardening.make debian/tmp/etc/epics/configure/conf.d/
 	echo "ALL_CROSS_COMPILER_TARGET_ARCHS += $(TARGETS)" > debian/tmp/etc/epics/configure/conf.d/01debug.make
 
 	install -d debian/tmp/usr/bin


### PR DESCRIPTION
Since #1 the epics-base package has been built with the debian hardening flags (eg. stack protect/relro).  Now add /etc/epics/configure/conf.d/05hardening.make so that dependent code will also do this.  I think this is fairly low risk.  On the chance that something does break, this can be disabled with the make variable 'SKIP_HARDENING=YES'.

05hardening.make is generated at package build time since calling dpkg-buildflags can be a little slow.