### PR TITLE
Install ascheck into folder /usr/bin

### DIFF
--- a/debian/epics-dev.install
+++ b/debian/epics-dev.install
@@ -12,6 +12,7 @@ usr/lib/epics/lib/linux-*/libdbCore*
 usr/lib/epics/lib/linux-*/libdbRecStd*
 usr/lib/epics/lib/host
 usr/lib/epics/lib/pkgconfig/*.pc usr/share/pkgconfig
+usr/bin/ascheck
 usr/bin/makeBaseApp
 usr/bin/makeBaseExt
 usr/bin/softIoc

--- a/debian/rules
+++ b/debian/rules
@@ -67,7 +67,7 @@ override_dh_epics_postinstall:
 
 override_dh_auto_test: # skip for development
 
-USRBINS=makeBaseApp.pl makeBaseExt.pl softIoc caget caput camonitor cainfo caRepeater casw msi iocLogServer
+USRBINS=makeBaseApp.pl makeBaseExt.pl softIoc caget caput camonitor cainfo caRepeater casw msi iocLogServer ascheck
 
 PERLBINS=caget.pl caput.pl camonitor.pl cainfo.pl capr.pl
 


### PR DESCRIPTION
Install the tool for syntax checking of access security config files into the system bin folder to make it more convenient to use.